### PR TITLE
Add i18next support

### DIFF
--- a/lib/i18n.es
+++ b/lib/i18n.es
@@ -1,13 +1,13 @@
 import {PLUGIN_NAME, LANGS, I18N_DATA_BASEDIR, LOCALE_CONFIG_KEY} from './constant';
 import {readJsonSync} from 'fs-extra'
 import _ from 'lodash'
+import path from 'path-extra'
 
 const readI18nResources = (filePath) => {
     try {
         let data = readJsonSync(filePath)
         data = _(data)
             .entries()
-            .map(([key, v]) => [escapeI18nKey(key), v])
             .fromPairs()
             .value()
         return data
@@ -29,31 +29,30 @@ export class I18nService {
     initialize = () => {
         try {
             i18next = require('i18next').createInstance()
-            i18next.use(reactI18nextModule)
             .init({
                 fallbackLng: false,
                 resources: _(LANGS).map(locale => ([
                     locale,
                     {
-                        translator: readOrIgnoreJsonSync(path.join(I18N_DATA_BASEDIR, `${locale}.json`)),
+                        translation: readI18nResources(path.join(I18N_DATA_BASEDIR, `${locale}.json`)),
                     },
                 ]))
                 .fromPairs()
                 .value(),
                 returnObjects: true,
             })
-            i18next.__ = i18next.getFixedT(this._locale)
+            i18next.__ = i18next.getFixedT(this._locale);
         } catch (e) {
             i18next = new(require('i18n-2'))({
                 locales: LANGS,
                 defaultLocale: 'ja-JP',
                 directory: I18N_DATA_BASEDIR,
                 devMode: false,
-                extension: '.json'
+                extension: '.json',
             });
             i18next.setLocale(this._locale);
-            return [I18nService.getPluginI18n(), I18nService.getDataI18n()];
         }
+        return [I18nService.getPluginI18n(), I18nService.getDataI18n()];
     };
 
     static getLocale() {
@@ -78,7 +77,7 @@ export class I18nService {
 
     static setLocale(locale) {
         if (i18next.getFixedT) {
-            i18next.__ = i18next.getFixedT(locale)
+            i18next.__ = i18next.getFixedT(this._locale);
         } else {
             i18n[PLUGIN_NAME].setLocale(locale);
             i18next.setLocale(locale);

--- a/lib/i18n.es
+++ b/lib/i18n.es
@@ -1,4 +1,22 @@
 import {PLUGIN_NAME, LANGS, I18N_DATA_BASEDIR, LOCALE_CONFIG_KEY} from './constant';
+import {readJsonSync} from 'fs-extra'
+import _ from 'lodash'
+
+const readI18nResources = (filePath) => {
+    try {
+        let data = readJsonSync(filePath)
+        data = _(data)
+            .entries()
+            .map(([key, v]) => [escapeI18nKey(key), v])
+            .fromPairs()
+            .value()
+        return data
+    } catch (e) {
+        return {}
+    }
+}
+
+let i18next
 
 export class I18nService {
 
@@ -9,15 +27,33 @@ export class I18nService {
     }
 
     initialize = () => {
-        i18n[`${PLUGIN_NAME}-data`] = new(require('i18n-2'))({
-            locales: LANGS,
-            defaultLocale: 'ja-JP',
-            directory: I18N_DATA_BASEDIR,
-            devMode: false,
-            extension: '.json'
-        });
-        i18n[`${PLUGIN_NAME}-data`].setLocale(this._locale);
-        return [I18nService.getPluginI18n(), I18nService.getDataI18n()];
+        try {
+            i18next = require('i18next').createInstance()
+            i18next.use(reactI18nextModule)
+            .init({
+                fallbackLng: false,
+                resources: _(LANGS).map(locale => ([
+                    locale,
+                    {
+                        translator: readOrIgnoreJsonSync(path.join(I18N_DATA_BASEDIR, `${locale}.json`)),
+                    },
+                ]))
+                .fromPairs()
+                .value(),
+                returnObjects: true,
+            })
+            i18next.__ = i18next.getFixedT(this._locale)
+        } catch (e) {
+            i18next = new(require('i18n-2'))({
+                locales: LANGS,
+                defaultLocale: 'ja-JP',
+                directory: I18N_DATA_BASEDIR,
+                devMode: false,
+                extension: '.json'
+            });
+            i18next.setLocale(this._locale);
+            return [I18nService.getPluginI18n(), I18nService.getDataI18n()];
+        }
     };
 
     static getLocale() {
@@ -33,16 +69,20 @@ export class I18nService {
     }
 
     static getPluginI18n()  {
-        return i18n[PLUGIN_NAME].__.bind(i18n[PLUGIN_NAME]);
+        return (...arg) => i18n[PLUGIN_NAME].__(...arg);
     }
 
     static getDataI18n() {
-        return i18n[PLUGIN_NAME + '-data'].__.bind(i18n[PLUGIN_NAME + '-data']);
+        return (...arg) => i18next.__(...arg);
     }
 
     static setLocale(locale) {
-        i18n[PLUGIN_NAME].setLocale(locale);
-        i18n[`${PLUGIN_NAME}-data`].setLocale(locale);
+        if (i18next.getFixedT) {
+            i18next.__ = i18next.getFixedT(locale)
+        } else {
+            i18n[PLUGIN_NAME].setLocale(locale);
+            i18next.setLocale(locale);
+        }
         window.config.set(LOCALE_CONFIG_KEY, locale);
         this._locale = locale;
     }


### PR DESCRIPTION
poi 8.2.0 use `i18next` as translate module and `i18n-2` will be deprecated in the next major version.
This pull request enables `i18next` support without breaking changes.