### PR TITLE
Use webRequest instead of did-get-response-details

### DIFF
--- a/index.es
+++ b/index.es
@@ -1,6 +1,11 @@
 import {Notifier} from './lib/notifier';
 import {DBG_EXTRA_HANDLER_NAME} from './lib/constant';
+import {remote} from 'electron';
 
+const {session} = remote
+const filter = {
+    urls: ['*kcs/sound*']
+}
 let notifier = {};
 
 export const
@@ -8,11 +13,14 @@ export const
         dbg.extra(DBG_EXTRA_HANDLER_NAME);
         notifier = new Notifier();
         notifier.initialize();
-        $('kan-game webview').addEventListener('did-get-response-details', notifier.handleResponseDetails);
+        session.defaultSession.webRequest.onBeforeRequest(filter, (e, c) => {
+            notifier.handleResponseDetails(e)
+            c({ cancel: false })
+        });
         window.addEventListener('game.response', notifier.handleGameResponse);
     },
     pluginWillUnload = (e) => {
-        $('kan-game webview').removeEventListener('did-get-response-details', notifier.handleResponseDetails);
+        session.defaultSession.webRequest.onBeforeRequest(filter, null);
         window.removeEventListener('game.response', notifier.handleGameResponse);
     };
 

--- a/lib/notifier.es
+++ b/lib/notifier.es
@@ -35,9 +35,9 @@ export class Notifier {
     }
 
     handleResponseDetails = (event) => {
-        const match = /kcs\/sound\/(.*?)\/(.*?).mp3/.exec(event.newURL);
+        const match = /kcs\/sound\/(.*?)\/(.*?).mp3/.exec(event.url);
         if (match && match.length === 3) {
-            debug(event.newURL);
+            debug(event.url);
             const [,shipCode, filename] = match;
             switch (shipCode) {
                 case 'kc9998':


### PR DESCRIPTION
'did-get-response-details' event is deprecated on Chrome 66 (aka. electron 3.0).
This pull request use `webRequest` module instead to fix event listeners