### PR TITLE
Update loader.es

### DIFF
--- a/lib/loader.es
+++ b/lib/loader.es
@@ -80,7 +80,7 @@ export class Loader {
                 url = `${REMOTE_HOST}/zh-tw/diff/`;
                 break;
             case 'en-US':
-                url = `${REMOTE_HOST}/en/diff`;
+                url = `${REMOTE_HOST}/en/diff/`;
                 break;
             default:
                 url = `${REMOTE_HOST}/jp/diff/`;
@@ -92,10 +92,10 @@ export class Loader {
         try {
             const responses = await request.getAsync(url);
             let responseBody = {};
+            const response = responses;
             if (_.isArray(responses)) {
                 responseBody = responses[1];
             } else {
-                const response = responses;
                 if (response.statusCode >= 300)
                     throwPluginError(`Network exception(${response.statusCode}): ${response.statusMessage}`);
                 responseBody = response.body;


### PR DESCRIPTION
Wrong scope of response causes it to be inexistant in `!_.isEmpty(updates)` check. Therefore errors are not properely logged.

_fetchSubtitleUpdates has a missing '/' in en-US link creator.