### PR TITLE
Provide Romaji names in subtitles for English version

### DIFF
--- a/lib/notifier.es
+++ b/lib/notifier.es
@@ -4,6 +4,7 @@ import { EXTRA_CATEGORIES } from './constant';
 import { debug, timeToNextHour } from './util';
 import { I18nService } from './i18n';
 import { Traditionalized } from './traditionalized';
+import { isKanji, toRomaji } from 'wanakana';
 const { getStore } = window;
 
 export class Notifier {
@@ -75,7 +76,7 @@ export class Notifier {
         let priority = 5;
         if (voiceId > 8 && voiceId < 11)
             priority = 0;
-        const shipName = this._ships[apiId].api_name;
+        const shipName = (I18nService.getLocale() === 'en-US') ? _.capitalize(toRomaji(this._ships[apiId].api_yomi)) : this._ships[apiId].api_name;
         if (voiceId < 30 || voiceId === 141 || voiceId === 241) {
             if (!quote) {
                 this._display(__('Subtitle Miss', shipName), priority);
@@ -106,7 +107,7 @@ export class Notifier {
             this._handleShortDrama(entity);
             return;
         }
-        const name = entity.name;
+        const name = (I18nService.getLocale() === 'en-US') ? _.capitalize(toRomaji(Object.values(this._ships).find(x => x.api_name == _name).api_yomi)) : entity.name;
         const quote = this._getQuoteByLocale(entity);
         if (!quote) {
             debug(`${title} subtitle missed: #${voiceId}`);
@@ -120,7 +121,8 @@ export class Notifier {
 
     _handleShortDrama(entities) {
         for (const entity of entities) {
-            const { name, time } = entity;
+            const time = entity.time;
+            const name = (I18nService.getLocale() === 'en-US') ? _.capitalize(toRomaji(Object.values(this._ships).find(x => x.api_name == _name).api_yomi)) : entity.name;
             const quote = this._getQuoteByLocale(entity);
             setTimeout(() => {
                 this._display(`${name}: ${quote}`);

--- a/lib/notifier.es
+++ b/lib/notifier.es
@@ -107,7 +107,7 @@ export class Notifier {
             this._handleShortDrama(entity);
             return;
         }
-        const name = (I18nService.getLocale() === 'en-US') ? _.capitalize(toRomaji(Object.values(this._ships).find(x => x.api_name == _name).api_yomi)) : entity.name;
+        const name = (I18nService.getLocale() === 'en-US') ? _.capitalize(toRomaji(Object.values(this._ships).find(x => x.api_name == entity.name).api_yomi)) : entity.name;
         const quote = this._getQuoteByLocale(entity);
         if (!quote) {
             debug(`${title} subtitle missed: #${voiceId}`);
@@ -122,7 +122,7 @@ export class Notifier {
     _handleShortDrama(entities) {
         for (const entity of entities) {
             const time = entity.time;
-            const name = (I18nService.getLocale() === 'en-US') ? _.capitalize(toRomaji(Object.values(this._ships).find(x => x.api_name == _name).api_yomi)) : entity.name;
+            const name = (I18nService.getLocale() === 'en-US') ? _.capitalize(toRomaji(Object.values(this._ships).find(x => x.api_name == entity.name).api_yomi)) : entity.name;
             const quote = this._getQuoteByLocale(entity);
             setTimeout(() => {
                 this._display(`${name}: ${quote}`);


### PR DESCRIPTION
As poi already uses a wanakana library, and API provides yomi pronunciation, names could be easily romanized for more consistent viewing experience.