### PR TITLE
Fix subtitle database choice discrepancy

### DIFF
--- a/lib/notifier.es
+++ b/lib/notifier.es
@@ -73,7 +73,8 @@ export class Notifier {
         if (!voiceId) return;
         debug(`apiId: ${apiId}, voiceId: ${voiceId}`);
         let subtitles = this._subtitles['ships'];
-        const quote = subtitles['zh-CN'][apiId] ? subtitles['zh-CN'][apiId][voiceId] : '';
+        const locale = I18nService.getLocale();
+        const quote = subtitles[locale][apiId] ? subtitles[locale][apiId][voiceId] : '';
         const { __, ___ } = this;
         debug(`i18n: ${___(apiId + '.' + voiceId)}`);
         let priority = 5;


### PR DESCRIPTION
Currently the plugin only checks for existence of provided subtitle in zh-CN database, and uses empty string if none is present - this creates a `Missing Line` discrepancy, as, for example, in case of Kishinami (ID: 527) there is no translation in that database, but such exists in en-US database, nevertheless the entry is still called as `Missing Line`. This PR fixes that discrepancy.