### PR TITLE
Pass shipNames to i18n to get translated names

### DIFF
--- a/lib/notifier.es
+++ b/lib/notifier.es
@@ -4,8 +4,10 @@ import { EXTRA_CATEGORIES } from './constant';
 import { debug, timeToNextHour } from './util';
 import { I18nService } from './i18n';
 import { Traditionalized } from './traditionalized';
-import { isKanji, toRomaji } from 'wanakana';
+
 const { getStore } = window;
+
+const t = window.i18n.resources.__;
 
 export class Notifier {
 
@@ -79,7 +81,7 @@ export class Notifier {
         let priority = 5;
         if (voiceId > 8 && voiceId < 11)
             priority = 0;
-        const shipName = (I18nService.getLocale() === 'en-US') ? _.capitalize(toRomaji(this._ships[apiId].api_yomi)) : this._ships[apiId].api_name;
+        const shipName = t(this._ships[apiId].api_name);
         if (voiceId < 30 || voiceId === 141 || voiceId === 241) {
             if (!quote) {
                 this._display(__('Subtitle Miss', shipName), priority);
@@ -110,7 +112,7 @@ export class Notifier {
             this._handleShortDrama(entity);
             return;
         }
-        const name = (I18nService.getLocale() === 'en-US') ? _.capitalize(toRomaji(Object.values(this._ships).find(x => x.api_name == entity.name).api_yomi)) : entity.name;
+        const name = t(entity.name);
         const quote = this._getQuoteByLocale(entity);
         if (!quote) {
             debug(`${title} subtitle missed: #${voiceId}`);
@@ -125,7 +127,7 @@ export class Notifier {
     _handleShortDrama(entities) {
         for (const entity of entities) {
             const time = entity.time;
-            const name = (I18nService.getLocale() === 'en-US') ? _.capitalize(toRomaji(Object.values(this._ships).find(x => x.api_name == entity.name).api_yomi)) : entity.name;
+            const name = t(entity.name);
             const quote = this._getQuoteByLocale(entity);
             setTimeout(() => {
                 this._display(`${name}: ${quote}`);

--- a/lib/notifier.es
+++ b/lib/notifier.es
@@ -31,7 +31,7 @@ export class Notifier {
         this._loader.getSubtitles().then((data) => {
             this._subtitles.ships = data;
             this.__ = I18nService.getPluginI18n();
-            this.__r = window.i18n.resources.__;
+            this.__r = (x) => window.i18n.resources.fixedT(x, {lng: I18nService.getLocale()});
             this.___ = I18nService.getDataI18n();
             callback && callback()
         });

--- a/lib/notifier.es
+++ b/lib/notifier.es
@@ -4,10 +4,7 @@ import { EXTRA_CATEGORIES } from './constant';
 import { debug, timeToNextHour } from './util';
 import { I18nService } from './i18n';
 import { Traditionalized } from './traditionalized';
-
 const { getStore } = window;
-
-const t = window.i18n.resources.__;
 
 export class Notifier {
 
@@ -17,6 +14,7 @@ export class Notifier {
     _timeoutHandle = -1;
     _loader = new Loader();
     __ = (x) => x;
+    __r = (x) => x;
     ___ = (x) => x;
 
     constructor() {
@@ -33,6 +31,7 @@ export class Notifier {
         this._loader.getSubtitles().then((data) => {
             this._subtitles.ships = data;
             this.__ = I18nService.getPluginI18n();
+            this.__r = window.i18n.resources.__;
             this.___ = I18nService.getDataI18n();
             callback && callback()
         });
@@ -67,7 +66,7 @@ export class Notifier {
     handleGameResponse = (event) => {
         clearTimeout(this._timeoutHandle);
     }
-
+  
     _handleShipVoice = (shipCode, filename) => {
         const apiId = this._shipGraph[shipCode.slice(2)];
         if (!apiId) return;
@@ -75,13 +74,14 @@ export class Notifier {
         if (!voiceId) return;
         debug(`apiId: ${apiId}, voiceId: ${voiceId}`);
         let subtitles = this._subtitles['ships'];
-        const quote = subtitles['zh-CN'][apiId] ? subtitles['zh-CN'][apiId][voiceId] : '';
-        const { __, ___ } = this;
+        const locale = I18nService.getLocale();
+        const quote = subtitles[locale][apiId] ? subtitles[locale][apiId][voiceId] : '';
+        const { __, __r, ___ } = this;
         debug(`i18n: ${___(apiId + '.' + voiceId)}`);
         let priority = 5;
         if (voiceId > 8 && voiceId < 11)
             priority = 0;
-        const shipName = t(this._ships[apiId].api_name);
+        const shipName = __r(this._ships[apiId].api_name);
         if (voiceId < 30 || voiceId === 141 || voiceId === 241) {
             if (!quote) {
                 this._display(__('Subtitle Miss', shipName), priority);
@@ -112,7 +112,7 @@ export class Notifier {
             this._handleShortDrama(entity);
             return;
         }
-        const name = t(entity.name);
+        const name = this.__r(entity.name);
         const quote = this._getQuoteByLocale(entity);
         if (!quote) {
             debug(`${title} subtitle missed: #${voiceId}`);
@@ -127,7 +127,7 @@ export class Notifier {
     _handleShortDrama(entities) {
         for (const entity of entities) {
             const time = entity.time;
-            const name = t(entity.name);
+            const name = this.__r(entity.name);
             const quote = this._getQuoteByLocale(entity);
             setTimeout(() => {
                 this._display(`${name}: ${quote}`);


### PR DESCRIPTION
As suggested on [#poi-viewer](https://github.com/poooi/poi/issues/1596) Discord, this PR delegates translations of names to i18n provided by poi-plugin-translator, instead of #22, being a much cleaner and more reliable solution, without downsides exposed in #23. 