### PR TITLE
Change webRequest listener type

### DIFF
--- a/index.es
+++ b/index.es
@@ -1,35 +1,32 @@
 import { Notifier } from './lib/notifier';
 import { DBG_EXTRA_HANDLER_NAME } from './lib/constant';
-import { remote } from 'electron';
 
-const { session } = remote
-const filter = {
-    urls: [
-        'http://*/kcs/sound/*',
-        'https://*/kcs/sound/*'
-    ]
-}
+import { ResourceNotifier } from 'views/services/resource-notifier'
+
 let notifier = {};
 
 export const
     pluginDidLoad = (e) => {
         dbg.extra(DBG_EXTRA_HANDLER_NAME);
         notifier = new Notifier();
-        notifier.initialize(() => {
-            const __ = notifier.__.bind(notifier)
-            session.defaultSession.webRequest.onBeforeSendHeaders(filter, (e, c) => {
+
+        notifier.handleSountRequest = function (e) {
+            if (e.url.includes('/kcs/sound/')) {
                 try {
                     notifier.handleResponseDetails(e)
                 } catch (err) {
                     console.error(err)
                 }
-                c({ cancel: false })
-            });
+            }
+        };
+        notifier.initialize(() => {
+            const __ = notifier.__.bind(notifier)
             window.addEventListener('game.response', notifier.handleGameResponse);
+            ResourceNotifier.addListener('request', notifier.handleSountRequest);
         });
     },
     pluginWillUnload = (e) => {
-        session.defaultSession.webRequest.onBeforeSendHeaders(filter, null);
+        ResourceNotifier.removeListener('request', notifier.handleSountRequest);
         window.removeEventListener('game.response', notifier.handleGameResponse);
     };
 

--- a/index.es
+++ b/index.es
@@ -17,7 +17,7 @@ export const
         notifier = new Notifier();
         notifier.initialize(() => {
             const __ = notifier.__.bind(notifier)
-            session.defaultSession.webRequest.onBeforeRequest(filter, (e, c) => {
+            session.defaultSession.webRequest.onBeforeSendHeaders(filter, (e, c) => {
                 try {
                     notifier.handleResponseDetails(e)
                 } catch (err) {
@@ -29,7 +29,7 @@ export const
         });
     },
     pluginWillUnload = (e) => {
-        session.defaultSession.webRequest.onBeforeRequest(filter, null);
+        session.defaultSession.webRequest.onBeforeSendHeaders(filter, null);
         window.removeEventListener('game.response', notifier.handleGameResponse);
     };
 


### PR DESCRIPTION
This plugin has been using `webRequest.onBeforeRequest` API to intercept the voice line MP3 requests since https://github.com/kcwikizh/poi-plugin-subtitle/pull/12 .

Due to the buggy design of electron, [webRequest events can accept only 1 listener each](https://github.com/electron/electron/issues/10478). 

It means that multiple plugins using `webRequest.onBeforeRequest` API will conflict and only the last loaded one will be working properly.

I have [another plugin](https://github.com/laplamgor/kantai3d-poi-plugin) that requires the redirectURL functionality of the `webRequest.onBeforeRequest` API. 

Unlike my plugin, subtitle plugin only needs to capture `event.url` and `event.webContentsId` which can be satisfied by other less powerful event types such as `webRequest.onSendHeaders` or `webRequest.onBeforeSendHeaders`.

Therefore this PR is to switch the usage of `webRequest.onBeforeRequest` to `webRequest.onBeforeSendHeaders` to avoid conflicts. I have done a simple file search and found none of built-in poi plugins using `webRequest.onBeforeSendHeaders`.


Ref: https://www.electronjs.org/docs/latest/api/web-request#webrequestonbeforesendheadersfilter-listener


### 中文TLDR:
因electron webRequest API限制造成插件衝突
onBeforeRequest, onSendHeaders, onBeforeSendHeaders 各自最多只能被一個插件使用
因為我的插件依賴redirectURL, 所以我必須用onBeforeRequest
字幕插件只要讀到URL就行，隨便用哪一種都不影響功能，所以希望能讓出onBeforeRequest而改用onBeforeSendHeaders 